### PR TITLE
workaround limitations of tempfile on win32

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -178,7 +178,7 @@ class RetDec(object):
             os.unlink('{}.c.frontend.dsm'.format(inputfile))
 
         os.unlink(tmpfilename)
-       
+
         return code
 
     def decompile_raw(self):

--- a/__init__.py
+++ b/__init__.py
@@ -170,11 +170,11 @@ class RetDec(object):
 
             os.unlink('{}.c'.format(inputfile))
             os.unlink('{}.c.frontend.dsm'.format(inputfile))
-            
+
             try:
                 conf.close()
                 os.unlink(conf.name)
-            except:
+            except OSError:
                 pass
 
         return code
@@ -190,11 +190,11 @@ class RetDec(object):
             self.load_function(f)
 
             code = self.decompile(f.name)
-            
+
             try:
                 f.close()
                 os.unlink(f.name)
-            except:
+            except OSError:
                 pass
 
         code = self.merge_symbols(code)

--- a/__init__.py
+++ b/__init__.py
@@ -152,7 +152,7 @@ class RetDec(object):
         self._cmdline.append('--cleanup')
 
     def decompile(self, inputfile):
-        with tempfile.NamedTemporaryFile(mode='w') as conf:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as conf:
             json.dump(self.conf.dump(), conf)
             conf.flush()
             self._cmdline.extend(['--config', conf.name])
@@ -170,6 +170,12 @@ class RetDec(object):
 
             os.unlink('{}.c'.format(inputfile))
             os.unlink('{}.c.frontend.dsm'.format(inputfile))
+            
+            try:
+                conf.close()
+                os.unlink(conf.name)
+            except:
+                pass
 
         return code
 
@@ -184,6 +190,12 @@ class RetDec(object):
             self.load_function(f)
 
             code = self.decompile(f.name)
+            
+            try:
+                f.close()
+                os.unlink(f.name)
+            except:
+                pass
 
         code = self.merge_symbols(code)
         self.render_output(code)

--- a/__init__.py
+++ b/__init__.py
@@ -220,6 +220,12 @@ class RetDec(object):
 
             code = self.decompile(f.name)
 
+            try:
+                f.close()
+                os.unlink(f.name)
+            except OSError:
+                pass
+
         code = self.merge_symbols(code)
         self.render_output(code)
 


### PR DESCRIPTION
with default `delete=True` kwarg, `NamedTemporaryFile` will throw EPERM on win32. you need to explicitly set `delete=False` and close and unlink the tempfile yourself for this to work on win32.